### PR TITLE
Fixes a bug where the file input for the CV upload would overlap the …

### DIFF
--- a/src/components/InputStep.tsx
+++ b/src/components/InputStep.tsx
@@ -135,11 +135,11 @@ We are looking for a Senior Software Engineer to join our growing team. The idea
         </div>
         
         <div
-          className={`border-2 border-dashed rounded-xl p-8 text-center transition-all duration-200 ${
-            dragActive 
-              ? 'border-primary bg-primary/5' 
-              : formData.cvFile 
-                ? 'border-success bg-success/5' 
+          className={`relative border-2 border-dashed rounded-xl p-8 text-center transition-all duration-200 ${
+            dragActive
+              ? 'border-primary bg-primary/5'
+              : formData.cvFile
+                ? 'border-success bg-success/5'
                 : 'border-border hover:border-primary/50'
           }`}
           onDragOver={(e) => { e.preventDefault(); setDragActive(true); }}


### PR DESCRIPTION
…job description text area, causing clicks on the text area to incorrectly open the file explorer.

The root cause was an absolutely positioned file input element that was not contained by its intended parent dropzone `div`. Because the parent `div` lacked `position: relative`, the file input was being positioned relative to a higher-level ancestor, causing it to cover other elements on the page.

The fix adds the `relative` Tailwind CSS class to the dropzone `div`, which sets `position: relative`. This establishes the dropzone as the containing block for the absolutely positioned file input, ensuring it is correctly constrained to the dropzone's boundaries and does not interfere with other UI elements.